### PR TITLE
Tidying Phylogenetic models + Markov bases algo added

### DIFF
--- a/experimental/AlgebraicStatistics/src/GaussianGraphicalModels.jl
+++ b/experimental/AlgebraicStatistics/src/GaussianGraphicalModels.jl
@@ -16,8 +16,6 @@ struct GaussianRing
     covariance_matrix
 end
 
-
-
 @doc raw"""
     gaussian_ring(n::Int; s_var_name::String="s", base_ring=QQ)
 
@@ -44,8 +42,6 @@ function gaussian_ring(n::Int, s_var_name::String="s", base_ring::Field=QQ)
 
     GaussianRing(S, d, cov_matrix)
 end
-
-
 
 function Base.show(io::IO, R::GaussianRing)
 

--- a/experimental/AlgebraicStatistics/src/PhylogeneticInvariants.jl
+++ b/experimental/AlgebraicStatistics/src/PhylogeneticInvariants.jl
@@ -3,120 +3,146 @@ struct PhylogeneticRing
   gens::Dict
 end
 
-function phylogenetic_ring(varindices::Vector{Tuple{Vararg{Int64}}}; var_name::VarName="p", F::Field=QQ)
-  varnames = ["$var_name[$(join(x, ", "))]" for x in varindices] 
-
+function phylogenetic_ring(F::Field, varindices::Vector{Tuple{Vararg{Int64}}}; var_name::VarName="p")
+  varnames = ["$var_name[$(join(x, ", "))]" for x in varindices]
   S, s = polynomial_ring(F, varnames)
   p = Dict([varindices[i] => s[i] for i in 1:length(varindices)])
 
   return PhylogeneticRing(S, p)
 end
 
+phylogenetic_ring(varindices::Vector{Tuple{Vararg{Int64}}}; var_name::VarName="p") = phylogenetic_model(QQ, varindices; var_name=var_name)
+ring(R::PhylogeneticRing) = R.ring
+base_ring(R::PhylogeneticRing) = base_ring(ring(R))
+
 function Base.show(io::IO, R::PhylogeneticRing)
-
-  coeffs = base_ring(R.ring)
-  k = ngens(R.ring)
- 
-  print(io, "Phylogenetic ring over $(coeffs) in $(k) variables", "\n", chop(string(gens(R.ring)), head = 16, tail = 1))
+  coeffs = base_ring(R)
+  k = ngens(ring(R))
+  print(io, "Phylogenetic ring over $(coeffs) in $(k) variables", "\n", chop(string(gens(ring(R))), head = 16, tail = 1))
 end
 
-function ring(R::PhylogeneticRing)
-  R.ring
-end
-
-function parameterization(pm::PhylogeneticModel; var_name::VarName="p", F::Field=QQ)
-
+function parameterization(F::Field, pm::PhylogeneticModel; var_name::VarName="p")
   p = probability_map(pm);
   p = compute_equivalent_classes(p)
   parametrization = p.parametrization
   indices = collect(keys(parametrization))
 
-  R = phylogenetic_ring(indices, var_name=var_name, F=F)
+  R = phylogenetic_ring(F, indices, var_name=var_name)
   S = probability_ring(pm)
   S, = polynomial_ring(F, vcat([string(x) for x in gens(S)]))
 
-  hom(Oscar.ring(R), S, reduce(vcat, [change_coefficient_ring(F, parametrization[k]) for k in indices]))
-
+  hom(ring(R), S, reduce(vcat, [change_coefficient_ring(F, parametrization[k]) for k in indices]))
 end
 
-function parameterization(pm::GroupBasedPhylogeneticModel; F::Field=QQ, coordinates::Symbol=:fourier)
+parameterization(pm::PhylogeneticModel; var_name::VarName="p") = parameterization(QQ, pm; var_name=var_name)
 
+function parameterization(F::Field, pm::GroupBasedPhylogeneticModel; coordinates::Symbol=:fourier)
   if coordinates == :probabilities
-     return parameterization(phylogenetic_model(pm), var_name="p", F=F)
+    return parameterization(F, phylogenetic_model(pm); var_name="p")
 
   elseif coordinates == :fourier
-      q = fourier_map(pm);
-      q = compute_equivalent_classes(q)
-      parametrization = q.parametrization
-      indices = collect(keys(parametrization))
-  
-      R = phylogenetic_ring(indices, var_name="q", F=F)
-      S = fourier_ring(pm)
-      S, = polynomial_ring(F, vcat([string(x) for x in gens(S)]))
+    q = fourier_map(pm);
+    q = compute_equivalent_classes(q)
+    parametrization = q.parametrization
+    indices = collect(keys(parametrization))
 
-      return hom(Oscar.ring(R), S, reduce(vcat, [change_coefficient_ring(F, parametrization[k]) for k in indices]))
+    R = phylogenetic_ring(F, indices, var_name="q")
+    S = fourier_ring(pm)
+    S, = polynomial_ring(F, vcat([string(x) for x in gens(S)]))
+
+    return hom(Oscar.ring(R), S, reduce(vcat, [change_coefficient_ring(F, parametrization[k]) for k in indices]))
+  else
+    error("Couldn't recognize coordinates type to be used in parameterization")
   end
-
 end
 
-function vanishing_ideal(pm::PhylogeneticModel; F::Field=QQ, algorithm::Symbol=:eliminate)
-  parametrization = parameterization(pm, F=F, coordinates=:probabilities)
+function vanishing_ideal(F::Field, pm::PhylogeneticModel; algorithm::Symbol=:eliminate)
+  parametrization = parameterization(F, pm) # seems like we don't even need this? coordinates=:probabilities)
 
   if algorithm == :kernel
-      invariants = kernel(parametrization)
+    invariants = kernel(parametrization)
   else
-      S = domain(parametrization)
-      R = codomain(parametrization)
+    S = domain(parametrization)
+    R = codomain(parametrization)
 
-      #elim_ring, elim_gens = polynomial_ring(coefficient_ring(R), vcat([string(x) for x in gens(R)], [string(x) for x in gens(S)]))
-      elim_ring, elim_gens = polynomial_ring(coefficient_ring(R), vcat(R.S, S.S))
+    #elim_ring, elim_gens = polynomial_ring(coefficient_ring(R), vcat([string(x) for x in gens(R)], [string(x) for x in gens(S)]))
+    elim_ring, elim_gens = polynomial_ring(coefficient_ring(R), vcat(R.S, S.S))
 
-      inject_R = hom(R, elim_ring, elim_gens[1:ngens(R)])
-      inject_S = hom(S, elim_ring, elim_gens[ngens(R)+1:ngens(elim_ring)])
+    inject_R = hom(R, elim_ring, elim_gens[1:ngens(R)])
+    inject_S = hom(S, elim_ring, elim_gens[ngens(R) + 1:ngens(elim_ring)])
 
-      I = ideal([inject_S(s) - inject_R(parametrization(s)) for s in gens(S)])
-     
-      if algorithm == :eliminate
-          invariants = eliminate(I, elim_gens[1:ngens(R)])
-      elseif algorithm == :f4
-          # F = GF(32003) #1206.6940
-          invariants = ideal(groebner_basis_f4(I, eliminate=ngens(R)))
+    I = ideal([inject_S(s) - inject_R(parametrization(s)) for s in gens(S)])
+
+    if algorithm == :eliminate
+      invariants = eliminate(I, elim_gens[1:ngens(R)])
+    elseif algorithm == :f4
+      # F = GF(32003) #1206.6940
+      invariants = ideal(groebner_basis_f4(I, eliminate=ngens(R)))
       # elseif algorithm == :4ti2
       # elseif algorithm == :MultigradedImplicitization
-      end
 
-      project_S = hom(elim_ring, S, z -> z, [repeat([1], ngens(R)); gens(S)])
-      invariants = project_S(invariants)
+    elseif algorithm == :m4ti2 # symbols cannot start with numbers
+      @req is_binomial(I) "Ideal must be a binomial ideal to use 4ti2 algorithm"
+      # we can probably avoid constructing the ideal in the future for this case
+      lat_gens = map(e -> e[2] - e[1],
+                     collect.(map(i -> exponents(i; ordering=lex(elim_ring)),
+                                  gens(I))))
+      markov_basis = markov4ti2(matrix(ZZ, lat_gens))
+      invariants = binomial_exponents_to_ideal(elim_ring, markov_basis)
+      # elseif algorithm == :MultigradedImplicitization
+    else
+      error("Couldn't recognize algorithm when computing the vanishing ideal")
+    end
+
+    project_S = hom(elim_ring, S, z -> z, [repeat([1], ngens(R)); gens(S)])
+    invariants = project_S(invariants)
   end
   invariants
 end
 
-function vanishing_ideal(pm::GroupBasedPhylogeneticModel; F::Field=QQ, coordinates::Symbol=:fourier, algorithm::Symbol = :eliminate)
-  parametrization = parameterization(pm, F=F, coordinates=coordinates)
+vanishing_ideal(pm::PhylogeneticModel;
+                algorithm::Symbol=:eliminate) = vanishing_ideal(QQ, pm; algorithm=algorithm)
+
+function vanishing_ideal(F::Field, pm::GroupBasedPhylogeneticModel; coordinates::Symbol=:fourier, algorithm::Symbol = :eliminate)
+  param = parameterization(F, pm, coordinates=coordinates)
 
   if algorithm == :kernel
-      invariants = kernel(parametrization)
+    invariants = kernel(param)
   else
-      S = domain(parametrization)
-      R = codomain(parametrization)
+    S = domain(param)
+    R = codomain(param)
 
-      elim_ring, elim_gens = polynomial_ring(coefficient_ring(R), vcat([string(x) for x in gens(R)], [string(x) for x in gens(S)]))
-      inject_R = hom(R, elim_ring, elim_gens[1:ngens(R)])
-      inject_S = hom(S, elim_ring, elim_gens[ngens(R)+1:ngens(elim_ring)])
+    elim_ring, elim_gens = polynomial_ring(coefficient_ring(R), vcat([string(x) for x in gens(R)], [string(x) for x in gens(S)]))
+    inject_R = hom(R, elim_ring, elim_gens[1:ngens(R)])
+    inject_S = hom(S, elim_ring, elim_gens[ngens(R)+1:ngens(elim_ring)])
 
-      I = ideal([inject_S(s) - inject_R(parametrization(s)) for s in gens(S)])
-     
-      if algorithm == :eliminate
-          invariants = eliminate(I, elim_gens[1:ngens(R)])
-      elseif algorithm == :f4
-          # F = GF(32003) #1206.6940
-          invariants = ideal(groebner_basis_f4(I, eliminate=ngens(R)))
-      # elseif algorithm == :4ti2
+    I = ideal([inject_S(s) - inject_R(param(s)) for s in gens(S)])
+
+    if algorithm == :eliminate
+      invariants = eliminate(I, elim_gens[1:ngens(R)])
+    elseif algorithm == :f4
+      # F = GF(32003) #1206.6940
+      invariants = ideal(groebner_basis_f4(I, eliminate=ngens(R)))
+
+    elseif algorithm == :m4ti2 # symbols cannot start with numbers
+      @req is_binomial(I) "Ideal must be a binomial ideal to use 4ti2 algorithm"
+      # we can probably avoid constructing the ideal in the future for this case
+      lat_gens = map(e -> e[2] - e[1],
+                     collect.(map(i -> exponents(i; ordering=lex(elim_ring)),
+                                  gens(I))))
+      markov_basis = Oscar.markov4ti2(matrix(ZZ, lat_gens))
+      invariants = eliminate(binomial_exponents_to_ideal(elim_ring, markov_basis),
+                             elim_gens[1:ngens(R)])
+      
       # elseif algorithm == :MultigradedImplicitization
-      end
+    end
 
-      project_S = hom(elim_ring, S, z -> z, [repeat([1], ngens(R)); gens(S)])
-      invariants = project_S(invariants)
+    project_S = hom(elim_ring, S, z -> z, [repeat([1], ngens(R)); gens(S)])
+    invariants = project_S(invariants)
   end
   invariants
 end
+
+vanishing_ideal(pm::GroupBasedPhylogeneticModel;
+                coordinates::Symbol=:fourier,
+                algorithm::Symbol=:eliminate) = vanishing_ideal(QQ, pm; coordinates=coordinates, algorithm=algorithm)

--- a/experimental/AlgebraicStatistics/src/PhylogeneticInvariants.jl
+++ b/experimental/AlgebraicStatistics/src/PhylogeneticInvariants.jl
@@ -112,3 +112,7 @@ vanishing_ideal(pm::PhylogeneticModel;
 vanishing_ideal(pm::GroupBasedPhylogeneticModel;
                 coordinates::Symbol=:fourier,
                 algorithm::Symbol=:eliminate) = vanishing_ideal(QQ, pm, parameterization(QQ, pm, coordinates); algorithm=algorithm)
+
+vanishing_ideal(F::Field, pm::GroupBasedPhylogeneticModel;
+                coordinates::Symbol=:fourier,
+                algorithm::Symbol=:eliminate) = vanishing_ideal(F, pm, parameterization(F, pm, coordinates); algorithm=algorithm)

--- a/experimental/AlgebraicStatistics/src/PhylogeneticInvariants.jl
+++ b/experimental/AlgebraicStatistics/src/PhylogeneticInvariants.jl
@@ -13,7 +13,7 @@ function phylogenetic_ring(F::Field, varindices::Vector{Tuple{Vararg{Int64}}}; v
   return PhylogeneticRing(S, p)
 end
 
-phylogenetic_ring(varindices::Vector{Tuple{Vararg{Int64}}}; var_name::VarName="p") = phylogenetic_model(QQ, varindices; var_name=var_name)
+phylogenetic_ring(varindices::Vector{Tuple{Vararg{Int64}}}; var_name::VarName="p") = phylogenetic_ring(QQ, varindices; var_name=var_name)
 ring(R::PhylogeneticRing) = R.ring
 base_ring(R::PhylogeneticRing) = base_ring(ring(R))
 
@@ -54,7 +54,7 @@ function parameterization(F::Field, pm::GroupBasedPhylogeneticModel, coordinates
     S = fourier_ring(pm)
     S, = polynomial_ring(F, vcat([string(x) for x in gens(S)]))
 
-    return hom(Oscar.ring(R), S, reduce(vcat, [change_coefficient_ring(F, parametrization[k]) for k in indices]))
+    return hom(ring(R), S, reduce(vcat, [change_coefficient_ring(F, parametrization[k]) for k in indices]))
   else
     error("Couldn't recognize coordinates type to be used in parameterization")
   end
@@ -92,12 +92,11 @@ function vanishing_ideal(F::Field, pm::PhyloModelUnion, param::MPolyAnyMap;
       lat_gens = map(e -> e[2] - e[1],
                      collect.(map(i -> exponents(i; ordering=lex(elim_ring)),
                                   gens(I))))
-      markov_basis = Oscar.markov4ti2(matrix(ZZ, lat_gens))
+      markov_basis = markov4ti2(matrix(ZZ, lat_gens))
       invariants = eliminate(binomial_exponents_to_ideal(elim_ring, markov_basis),
                              elim_gens[1:ngens(R)])
       # elseif algorithm == :MultigradedImplicitization
     end
-
     project_S = hom(elim_ring, S, z -> z, [repeat([1], ngens(R)); gens(S)])
     invariants = project_S(invariants)
   end

--- a/experimental/AlgebraicStatistics/test/runtests.jl
+++ b/experimental/AlgebraicStatistics/test/runtests.jl
@@ -1,5 +1,4 @@
 @testset "GaussianGraphicalModels" begin
-
   S = gaussian_ring(3)
   s = gens(S)
   G = graph_from_edges(Directed, [[1,2],[2,3]])
@@ -40,6 +39,8 @@ end
     # group of the model
     G = group_of_model(model)
     @test is_isomorphic(unique(parent.(G))[1], abelian_group(2))
+
+    @test vanishing_ideal(QQ, model) == vanishing_ideal(QQ, model; algorithm=:m4ti2)
   end
 
   @testset "Jukes Cantor" begin


### PR DESCRIPTION
I've made some somewhat structural changes that are more accustome to Oscar. 
For example, if a ring is ever an arguement in a function it is always the first argument.
There are some examples where I took it out of a kwarg.
You'll see that in these cases I add a function that doesn't include the ring at all and it just calls
the same function with the default ring as the first entry (you'll see what I mean when you take a look at the code)

I've added a :mti2 option for and a first working example with a test for it in the cavender_farris_neyman_model test.
On the example in the test, the markov implementation takes half the time. I am not totally sure if this is still the optimal 
but I figure is an ok start.