### PR TITLE
Markov properties

### DIFF
--- a/experimental/AlgebraicStatistics/src/AlgebraicStatistics.jl
+++ b/experimental/AlgebraicStatistics/src/AlgebraicStatistics.jl
@@ -17,6 +17,7 @@ end
 
 include("ModelRing.jl")
 include("CI.jl")
+include("MarkovProperties.jl")
 include("Markov.jl")
 include("GraphicalModels.jl")
 include("GaussianGraphicalModels.jl")
@@ -103,3 +104,8 @@ export ci_polynomial
 export ci_structure
 export random_variables
 
+# Markov properties
+export pairwise_markov
+export local_markov
+export global_markov
+export are_separated

--- a/experimental/AlgebraicStatistics/src/AlgebraicStatistics.jl
+++ b/experimental/AlgebraicStatistics/src/AlgebraicStatistics.jl
@@ -109,3 +109,6 @@ export pairwise_markov
 export local_markov
 export global_markov
 export are_separated
+export is_ancestral
+export ancestral_closure
+export moralization

--- a/experimental/AlgebraicStatistics/src/CI.jl
+++ b/experimental/AlgebraicStatistics/src/CI.jl
@@ -61,12 +61,12 @@ Base.:(==)(lhs::CIStmt, rhs::CIStmt) =
   lhs.I == rhs.I && lhs.J == rhs.J && lhs.K == rhs.K
 
 @doc raw"""
-    Base.hash(stmt:;CIStmt, h::UInt)
+    Base.hash(stmt::CIStmt, h::UInt)
 
 Compute the hash of a `CIStmt`.
 """
 Base.hash(stmt::CIStmt, h::UInt) =
-  foldr(hash, stmt.I, stmt.J, stmt.K; init=hash(CIStmt, h))
+  foldr(hash, [stmt.I, stmt.J, stmt.K]; init=hash(CIStmt, h))
 
 @doc raw"""
     CI"I...,J...|K..."

--- a/experimental/AlgebraicStatistics/src/DiscreteGraphicalModels.jl
+++ b/experimental/AlgebraicStatistics/src/DiscreteGraphicalModels.jl
@@ -183,12 +183,12 @@ function parametrization(M::DiscreteGraphicalModel{Graph{Undirected}, L}) where 
 end
 
 @doc raw"""
-    ci_structure(M::DiscreteGraphicalModel{Undirected, L})
+    ci_structure(M::DiscreteGraphicalModel{Graph{Undirected}, L})
 
 Return the set of elementary CI statements which are satisfied by every distribution in the
 graphical model. This is the same as the `global_markov` property of the underlying graph.
 """
-function ci_structure(M::DiscreteGraphicalModel{Undirected, L}) where L
+function ci_structure(M::DiscreteGraphicalModel{Graph{Undirected}, L}) where L
   global_markov(graph(M))
 end
 
@@ -303,11 +303,11 @@ p[2, 2, 2] -> t[1, 2](2, 2)*t[2, 3](2, 2)
 # end
 
 @doc raw"""
-    ci_structure(M::DiscreteGraphicalModel{Directed, L})
+    ci_structure(M::DiscreteGraphicalModel{Graph{Directed}, L})
 
 Return the set of elementary CI statements which are satisfied by every distribution in the
 graphical model. This is the same as the `global_markov` property of the underlying graph.
 """
-function ci_structure(M::DiscreteGraphicalModel{Directed, L}) where L
+function ci_structure(M::DiscreteGraphicalModel{Graph{Directed}, L}) where L
   global_markov(graph(M))
 end

--- a/experimental/AlgebraicStatistics/src/DiscreteGraphicalModels.jl
+++ b/experimental/AlgebraicStatistics/src/DiscreteGraphicalModels.jl
@@ -182,6 +182,16 @@ function parametrization(M::DiscreteGraphicalModel{Graph{Undirected}, L}) where 
   hom(S, R, images)
 end
 
+@doc raw"""
+    ci_structure(M::DiscreteGraphicalModel{Undirected, L})
+
+Return the set of elementary CI statements which are satisfied by every distribution in the
+graphical model. This is the same as the `global_markov` property of the underlying graph.
+"""
+function ci_structure(M::DiscreteGraphicalModel{Undirected, L}) where L
+  global_markov(graph(M))
+end
+
 ###################################################################################
 #
 #       Directed Discrete Graphical Models
@@ -291,3 +301,13 @@ p[2, 2, 2] -> t[1, 2](2, 2)*t[2, 3](2, 2)
 # 
 #   return hom(ring(S), R, map(f -> reduce(f, gens(I)), images))
 # end
+
+@doc raw"""
+    ci_structure(M::DiscreteGraphicalModel{Directed, L})
+
+Return the set of elementary CI statements which are satisfied by every distribution in the
+graphical model. This is the same as the `global_markov` property of the underlying graph.
+"""
+function ci_structure(M::DiscreteGraphicalModel{Directed, L}) where L
+  global_markov(graph(M))
+end

--- a/experimental/AlgebraicStatistics/src/GaussianGraphicalModels.jl
+++ b/experimental/AlgebraicStatistics/src/GaussianGraphicalModels.jl
@@ -282,6 +282,16 @@ function parametrization(M::GaussianGraphicalModel{<: AbstractGraph{T}, L}) wher
   return hom(S, R, gens_map)
 end
 
+@doc raw"""
+    ci_structure(M::GaussianGraphicalModel{Directed, L})
+
+Return the set of elementary CI statements which are satisfied by every distribution in the
+graphical model. This is the same as the `global_markov` property of the underlying graph.
+"""
+function ci_structure(M::GaussianGraphicalModel{Directed, L}) where L
+  global_markov(graph(M))
+end
+
 ###################################################################################
 #
 #       Undirected parametrization
@@ -366,6 +376,16 @@ function parametrization(M::GaussianGraphicalModel{Graph{Undirected}, T}) where 
   Rloc, iota = localization(R, powers_of_element(det(K)))
   adj = adjugate(K)
   hom(S, Rloc, reduce(vcat, [[iota(adj[i,j])/iota(det(K)) for j in i:n_vertices(G)] for i in 1:n_vertices(G)]))
+end
+
+@doc raw"""
+    ci_structure(M::GaussianGraphicalModel{Undirected, T})
+
+Return the set of elementary CI statements which are satisfied by every distribution in the
+graphical model. This is the same as the `global_markov` property of the underlying graph.
+"""
+function ci_structure(M::GaussianGraphicalModel{Undirected, T}) where T
+  global_markov(graph(M))
 end
 
 ###################################################################################

--- a/experimental/AlgebraicStatistics/src/GaussianGraphicalModels.jl
+++ b/experimental/AlgebraicStatistics/src/GaussianGraphicalModels.jl
@@ -283,12 +283,12 @@ function parametrization(M::GaussianGraphicalModel{<: AbstractGraph{T}, L}) wher
 end
 
 @doc raw"""
-    ci_structure(M::GaussianGraphicalModel{Directed, L})
+    ci_structure(M::GaussianGraphicalModel{Graph{Directed}, L})
 
 Return the set of elementary CI statements which are satisfied by every distribution in the
 graphical model. This is the same as the `global_markov` property of the underlying graph.
 """
-function ci_structure(M::GaussianGraphicalModel{Directed, L}) where L
+function ci_structure(M::GaussianGraphicalModel{Graph{Directed}, L}) where L
   global_markov(graph(M))
 end
 
@@ -379,12 +379,12 @@ function parametrization(M::GaussianGraphicalModel{Graph{Undirected}, T}) where 
 end
 
 @doc raw"""
-    ci_structure(M::GaussianGraphicalModel{Undirected, T})
+    ci_structure(M::GaussianGraphicalModel{Graph{Undirected}, T})
 
 Return the set of elementary CI statements which are satisfied by every distribution in the
 graphical model. This is the same as the `global_markov` property of the underlying graph.
 """
-function ci_structure(M::GaussianGraphicalModel{Undirected, T}) where T
+function ci_structure(M::GaussianGraphicalModel{Graph{Undirected}, T}) where T
   global_markov(graph(M))
 end
 

--- a/experimental/AlgebraicStatistics/src/MarkovProperties.jl
+++ b/experimental/AlgebraicStatistics/src/MarkovProperties.jl
@@ -1,0 +1,175 @@
+# -*- Undirected graphs -*-
+
+@doc raw"""
+    pairwise_markov(G::Graph{Undirected})
+
+Return all *elementary* CI statements in the pairwise Markov property of `G`,
+i.e., all `CIStmt([i],[j],K)` such that `i` and `j` are not adjacent and
+`K = setdiff(vertices(G), [i,j])`.
+
+## Examples
+
+```jldoctest
+julia> G = graph_from_edges(Undirected, [[1,2],[2,3],[1,4],[4,5]])
+Undirected graph with 5 nodes and the following edges:
+(2, 1)(3, 2)(4, 1)(5, 4)
+
+julia> pairwise_markov(G)
+6-element Vector{CIStmt}:
+ [1 _||_ 3 | {2, 4, 5}]
+ [1 _||_ 5 | {2, 3, 4}]
+ [2 _||_ 4 | {1, 3, 5}]
+ [2 _||_ 5 | {1, 3, 4}]
+ [3 _||_ 4 | {1, 2, 5}]
+ [3 _||_ 5 | {1, 2, 4}]
+```
+"""
+function pairwise_markov(G::Graph{Undirected})::Vector{CIStmt}
+  V = vertices(G)
+  [ci_stmt([i], [j], setdiff(V, [i,j])) for i in 1:length(V) for j in (i+1):length(V)
+    if !has_edge(G, i, j)]
+end
+
+@doc raw"""
+    local_markov(G::Graph{Undirected})
+
+Return all *elementary* CI statements in the local Markov property of `G`,
+i.e., all `CIStmt([i],[j],K)` such that `i` and `j` are not adjacent and
+`K` is the set of neighbors of `i`.
+
+## Examples
+
+```jldoctest
+julia> G = graph_from_edges(Undirected, [[1,2],[2,3],[1,4],[4,5]])
+Undirected graph with 5 nodes and the following edges:
+(2, 1)(3, 2)(4, 1)(5, 4)
+
+julia> local_markov(G)
+12-element Vector{CIStmt}:
+ [1 _||_ 3 | {2, 4}]
+ [1 _||_ 5 | {2, 4}]
+ [2 _||_ 4 | {1, 3}]
+ [2 _||_ 5 | {1, 3}]
+ [1 _||_ 3 | 2]
+ [3 _||_ 4 | 2]
+ [3 _||_ 5 | 2]
+ [2 _||_ 4 | {1, 5}]
+ [3 _||_ 4 | {1, 5}]
+ [1 _||_ 5 | 4]
+ [2 _||_ 5 | 4]
+ [3 _||_ 5 | 4]
+```
+"""
+function local_markov(G::Graph{Undirected})::Vector{CIStmt}
+  V = vertices(G)
+  unique([ci_stmt([i], [j], neighbors(G, i)) for i in 1:length(V) for j in 1:length(V)
+          if i != j && !has_edge(G, i, j)])
+end
+
+@doc raw"""
+    are_separated(G::Graph{Undirected}, i::Int, j::Int, K::Vector{Int})
+
+Check if `i` and `j` are separated by `K` in the graph `G`, i.e., whether
+every path connecting `i` and `j` contains a node from `K`.
+
+## Examples
+
+```jldoctest
+julia> G = graph_from_edges(Undirected, [[1,2],[2,3],[2,4],[3,4]])
+Undirected graph with 4 nodes and the following edges:
+(2, 1)(3, 2)(4, 2)(4, 3)
+
+julia> are_separated(G, 1, 4, [2])
+true
+
+julia> are_separated(G, 1, 4, [3])
+false
+```
+"""
+function are_separated(G::Graph{Undirected}, i::Int, j::Int, K::Vector{Int})::Bool
+  V = vertices(G)
+  todo = [ [setdiff(V, i), [i]] ]
+  while !isempty(todo)
+    cur = pop!(todo)
+    W = cur[1]
+    p = cur[2]
+    v = p[end]
+    if v == j
+      if length(intersect(p, K)) == 0
+        return false
+      end
+    end
+    append!(todo, [ [setdiff(W, w), [p..., w]] for w in neighbors(G, v) if w in W])
+  end
+  return true
+end
+
+@doc raw"""
+    global_markov(G::Graph{Undirected})
+
+Return all *elementary* CI statements in the global Markov property of `G`,
+i.e., all `CIStmt([i],[j],K)` such that `K` separates `i` and `j` in `G`
+(see `are_separated`).
+
+## Examples
+
+```jldoctest
+julia> G = graph_from_edges(Undirected, [[1,2],[2,3],[1,4],[4,5]])
+Undirected graph with 5 nodes and the following edges:
+(2, 1)(3, 2)(4, 1)(5, 4)
+
+julia> global_markov(G)
+31-element Vector{CIStmt}:
+ [1 _||_ 3 | 2]
+ [1 _||_ 3 | {2, 5}]
+ [1 _||_ 3 | {2, 4}]
+ [1 _||_ 3 | {2, 4, 5}]
+ [1 _||_ 5 | 4]
+ [1 _||_ 5 | {2, 4}]
+ [1 _||_ 5 | {3, 4}]
+ [1 _||_ 5 | {2, 3, 4}]
+ [2 _||_ 4 | 1]
+ [2 _||_ 4 | {1, 5}]
+ [2 _||_ 4 | {1, 3}]
+ [2 _||_ 4 | {1, 3, 5}]
+ [2 _||_ 5 | 1]
+ [2 _||_ 5 | 4]
+ [2 _||_ 5 | {1, 4}]
+ [2 _||_ 5 | {3, 4}]
+ [2 _||_ 5 | {1, 3}]
+ [2 _||_ 5 | {1, 3, 4}]
+ [3 _||_ 4 | 1]
+ [3 _||_ 4 | 2]
+ [3 _||_ 4 | {1, 5}]
+ [3 _||_ 4 | {2, 5}]
+ [3 _||_ 4 | {1, 2}]
+ [3 _||_ 4 | {1, 2, 5}]
+ [3 _||_ 5 | 1]
+ [3 _||_ 5 | 2]
+ [3 _||_ 5 | 4]
+ [3 _||_ 5 | {1, 4}]
+ [3 _||_ 5 | {2, 4}]
+ [3 _||_ 5 | {1, 2}]
+ [3 _||_ 5 | {1, 2, 4}]
+```
+"""
+function global_markov(G::Graph{Undirected})::Vector{CIStmt}
+  V = vertices(G)
+  stmts = CIStmt[]
+  for i in 1:length(V)
+    for j in 1:length(V)
+      if i == j
+        continue
+      end
+      M = setdiff(V, [i,j])
+      for k in 0:length(M)
+        for K in subsets(M, k)
+          if are_separated(G, i, j, K)
+            push!(stmts, ci_stmt([i], [j], K))
+          end
+        end
+      end
+    end
+  end
+  return unique(stmts)
+end

--- a/experimental/AlgebraicStatistics/src/MarkovProperties.jl
+++ b/experimental/AlgebraicStatistics/src/MarkovProperties.jl
@@ -25,8 +25,8 @@ julia> pairwise_markov(G)
 ```
 """
 function pairwise_markov(G::Graph{Undirected})::Vector{CIStmt}
-  V = vertices(G)
-  [ci_stmt([i], [j], setdiff(V, [i,j])) for i in 1:length(V) for j in (i+1):length(V)
+  n = n_vertices(G)
+  [ci_stmt([i], [j], setdiff(V, [i,j])) for i in 1:n for j in (i+1):n
     if !has_edge(G, i, j)]
 end
 
@@ -61,8 +61,8 @@ julia> local_markov(G)
 ```
 """
 function local_markov(G::Graph{Undirected})::Vector{CIStmt}
-  V = vertices(G)
-  unique([ci_stmt([i], [j], neighbors(G, i)) for i in 1:length(V) for j in 1:length(V)
+  n = n_vertices(G)
+  unique([ci_stmt([i], [j], neighbors(G, i)) for i in 1:n for j in 1:n
           if i != j && !has_edge(G, i, j)])
 end
 
@@ -289,9 +289,9 @@ end
 function moralization(G::Graph{Directed}, A::Vector{Int})
   @req is_ancestral(G, A) "the moralization set must be ancestral"
   V = vertices(G)
-  # XXX: Since Oscar's graphs can only have vertex sets of the form 1:m,
-  # we have to very carefully relabel the edges so that vertex i in the
-  # moralization corresponds to vertex A[i] in the original graph.
+  # Since Oscar's graphs can only have vertex sets of the form 1:m,
+  # we have to very carefully relabel the edges so that vertex i in
+  # the moralization corresponds to vertex A[i] in the original graph.
   M = Graph{Undirected}(length(A))
   for i in 1:length(A)
     for j in 1:length(A)

--- a/experimental/AlgebraicStatistics/src/MarkovProperties.jl
+++ b/experimental/AlgebraicStatistics/src/MarkovProperties.jl
@@ -87,6 +87,7 @@ false
 ```
 """
 function are_separated(G::Graph{Undirected}, i::Int, j::Int, K::Vector{Int})::Bool
+  @req i != j && !(i in K) && !(j in K) "i and j must be distinct and not in K"
   V = vertices(G)
   todo = [ [setdiff(V, i), [i]] ]
   while !isempty(todo)
@@ -154,22 +155,223 @@ julia> global_markov(G)
 ```
 """
 function global_markov(G::Graph{Undirected})::Vector{CIStmt}
+  [stmt for stmt in ci_statements(collect(vertices(G)))
+   if are_separated(G, stmt.I[1], stmt.J[1], stmt.K)]
+end
+
+# -*- Directed acyclic graphs -*-
+
+parents(G::Graph{Directed}, i::Int)  =  inneighbors(G, i)
+children(G::Graph{Directed}, i::Int) = outneighbors(G, i)
+
+# TODO: These helpers are either already in polymake or should be optimized
+# and put somewhere deeper in the Graph code.
+# TODO: There is some amount of code duplication because all of these
+# algorithms are variants of depth-first search.
+
+function is_acyclic(G::Graph{Directed})::Bool
+  V = vertices(G)
+  todo = [ [setdiff(V, i), [i, i]] for i in V ]
+  while !isempty(todo)
+    cur = pop!(todo)
+    W = cur[1]
+    p = cur[2]
+    if has_edge(G, p[2], p[1])
+      return false
+    end
+    append!(todo, [ [setdiff(W, w), [p[1], w]] for w in children(G, p[2]) if w in W])
+  end
+  return true
+end
+
+function descendants(G::Graph{Directed}, i::Int)::Set{Int}
+  V = vertices(G)
+  d = Set{Int}(i)
+  todo = [ [setdiff(V, i), i] ]
+  while !isempty(todo)
+    cur = pop!(todo)
+    W = cur[1]
+    v = cur[2]
+    C = children(G, v)
+    union!(d, C)
+    append!(todo, [ [setdiff(W, w), w] for w in C if w in W])
+  end
+  return d
+end
+
+nondescendants(G::Graph{Directed}, i::Int) = setdiff(vertices(G), descendants(G, i))
+
+@doc raw"""
+    pairwise_markov(G::Graph{Directed})
+
+Return all *elementary* CI statements in the pairwise Markov property of `G`,
+i.e., all `CIStmt([i],[j],K)` such that `j` is a non-parent as well as non-descendant
+of `i` and `K = setdiff(nondescendants(G, i), j)`.
+
+## Examples
+
+```jldoctest
+julia> G = graph_from_edges(Directed, [[1,2],[1,3],[2,3],[3,4]])
+Directed graph with 4 nodes and the following edges:
+(1, 2)(1, 3)(2, 3)(3, 4)
+
+julia> pairwise_markov(G)
+2-element Vector{CIStmt}:
+ [1 _||_ 4 | {2, 3}]
+ [2 _||_ 4 | {1, 3}]
+```
+"""
+function pairwise_markov(G::Graph{Directed})::Vector{CIStmt}
   V = vertices(G)
   stmts = CIStmt[]
-  for i in 1:length(V)
-    for j in 1:length(V)
-      if i == j
-        continue
-      end
-      M = setdiff(V, [i,j])
-      for k in 0:length(M)
-        for K in subsets(M, k)
-          if are_separated(G, i, j, K)
-            push!(stmts, ci_stmt([i], [j], K))
-          end
-        end
+  for i in V
+    nd = nondescendants(G, i)
+    B = setdiff(nd, parents(G, i))
+    append!(stmts, [ci_stmt([i], [j], setdiff(nd, j)) for j in B])
+  end
+  unique(stmts)
+end
+
+@doc raw"""
+    local_markov(G::Graph{Directed})
+
+Return all *elementary* CI statements in the local Markov property of `G`,
+i.e., all `CIStmt([i],[j],K)` such that `j` is a non-parent as well as non-descendent
+of `i` and `K = parents(G, i)`.
+
+## Examples
+
+```jldoctest
+julia> G = graph_from_edges(Directed, [[1,2],[1,3],[2,3],[3,4]])
+Directed graph with 4 nodes and the following edges:
+(1, 2)(1, 3)(2, 3)(3, 4)
+
+julia> local_markov(G)
+2-element Vector{CIStmt}:
+ [1 _||_ 4 | 3]
+ [2 _||_ 4 | 3]
+```
+"""
+function local_markov(G::Graph{Directed})::Vector{CIStmt}
+  V = vertices(G)
+  stmts = CIStmt[]
+  for i in V
+    pa = parents(G, i)
+    B = setdiff(nondescendants(G, i), pa)
+    append!(stmts, [ci_stmt([i], [j], pa) for j in B])
+  end
+  unique(stmts)
+end
+
+function is_ancestral(G::Graph{Directed}, A::Vector{Int})::Bool
+  for v in setdiff(vertices(G), A)
+    for w in A
+      if has_edge(G, v, w) && !(v in A)
+        return false
       end
     end
   end
-  return unique(stmts)
+  return true
+end
+
+function ancestral_closure(G::Graph{Directed}, A::Vector{Int})::Vector{Int}
+  for v in setdiff(vertices(G), A)
+    for w in A
+      if has_edge(G, v, w) && !(v in A)
+        # Add v and restart
+        return ancestral_closure(G, [A..., v])
+      end
+    end
+  end
+  return A # if we get here, A was ancestral
+end
+
+function moralization(G::Graph{Directed}, A::Vector{Int})
+  @req is_ancestral(G, A) "the moralization set must be ancestral"
+  V = vertices(G)
+  # XXX: Since Oscar's graphs can only have vertex sets of the form 1:m,
+  # we have to very carefully relabel the edges so that vertex i in the
+  # moralization corresponds to vertex A[i] in the original graph.
+  M = Graph{Undirected}(length(A))
+  for i in 1:length(A)
+    for j in 1:length(A)
+      if i == j
+        continue
+      end
+      if has_edge(G, A[i], A[j]) || any(w -> has_edge(G, A[i], w) && has_edge(G, A[j], w), A)
+        add_edge!(M, i, j)
+      end
+    end
+  end
+  return M
+end
+
+@doc raw"""
+    are_separated(G::Graph{Directed}, i::Int, j::Int, K::Vector{Int})
+
+Check if `i` and `j` are d-separated by `K` in the graph `G`, i.e., whether
+`i` and `j` are separated by `K` in the moral graph `moralization(G, ancestral_closure(G, [i,j,K...]))`.
+
+## Examples
+
+```jldoctest
+julia> G = graph_from_edges(Directed, [[1,2],[2,3],[2,4],[3,4]])
+Undirected graph with 4 nodes and the following edges:
+(2, 1)(3, 2)(4, 2)(4, 3)
+
+julia> are_separated(G, 1, 4, [2])
+true
+
+julia> are_separated(G, 1, 4, [3])
+false
+```
+"""
+function are_separated(G::Graph{Directed}, i::Int, j::Int, K::Vector{Int})::Bool
+  @req i != j && !(i in K) && !(j in K) "i and j must be distinct and not in K"
+  A = ancestral_closure(G, [i, j, K...])
+  U = moralization(G, A)
+  # The moralization has vertices indexed by 1:m which correspond to the
+  # elements of A in order. We must test whether 1 is separated by 2 given
+  # the elements 3:length(K)+2
+  return are_separated(U, 1, 2, collect(3:(length(K)+2)))
+end
+
+@doc raw"""
+    global_markov(G::Graph{Directed})
+
+Return all *elementary* CI statements in the global Markov property of `G`,
+i.e., all `CIStmt([i],[j],K)` such that `K` d-separates `i` and `j` in `G`
+(see `are_separated`).
+
+## Examples
+
+```jldoctest
+julia> G = graph_from_edges(Directed, [[1,2],[1,3],[2,3],[3,4]])
+Directed graph with 4 nodes and the following edges:
+(1, 2)(1, 3)(2, 3)(3, 4)
+
+julia> global_markov(G)
+4-element Vector{CIStmt}:
+ [1 _||_ 4 | 3]
+ [1 _||_ 4 | {2, 3}]
+ [2 _||_ 4 | 3]
+ [2 _||_ 4 | {1, 3}]
+```
+
+```jldoctest
+julia> G = graph_from_edges(Directed, [[1,3],[2,3]])
+Directed graph with 3 nodes and the following edges:
+(1, 3)(2, 3)
+
+julia> global_markov(G)
+1-element Vector{CIStmt}:
+ [1 _||_ 2 | {}]
+```
+"""
+# TODO: Bayes Ball to get the CI statements more quickly?
+# TODO: For now, this is precisely the same algorithm as for the
+# undirected case because all the work is done in `are_separated`.
+function global_markov(G::Graph{Directed})::Vector{CIStmt}
+  [stmt for stmt in ci_statements(collect(vertices(G)))
+   if are_separated(G, stmt.I[1], stmt.J[1], stmt.K)]
 end


### PR DESCRIPTION
This implements the classical pairwise, local and global Markov properties for undirected and directed graphs. These functions are good to have in version 1.0 because (a) Macaulay2's `GraphicalModels` has them and (b) they can be used to speed up vanishing ideal computations for these types of graphical models.

In the process I discovered that hashing of `CIStmt` objects was broken and fixed it.

Also note that I had to add a bunch of general graph-related functions. It's not clear to me if those are available in polymake but not plugged into the Julia side or if those functions should be moved into the `Combinatorics` package. In any case, it's probably better to defer this until we are looking to actually merge our branch.