### PR TITLE
Fix `vanishing_ideal` with localized parameter rings

### DIFF
--- a/experimental/AlgebraicStatistics/src/GraphicalModels.jl
+++ b/experimental/AlgebraicStatistics/src/GraphicalModels.jl
@@ -58,7 +58,10 @@ Returns a map from the model ring to the parameter ring.
 """
 parametrization(M::T) where T <: GraphicalModel = error("Please implement the method parametrization for $T")
 
-
+# Below we make the ideal of the graph of a map. These methods allow us
+# to work transparently with a polynomial and a rational map.
+numerator(f::MPolyRingElem) = f
+denominator(f::MPolyRingElem) = parent(f)(1)
 
 #TODO update docs with an example?
 @doc raw"""
@@ -74,13 +77,23 @@ function vanishing_ideal(GM::GraphicalModel; algorithm::Symbol = :eliminate)
   else
     S = domain(phi)
     R = codomain(phi)
-    
+
+    if R isa MPolyLocRing # Rational parametrization
+      U = inverted_set(R)
+      R = base_ring(R)
+    else # Polynomial parametrization
+      U = nothing
+    end
+    @req coefficient_ring(R) == coefficient_ring(S) "coefficient fields of parameter and model ring must be the same"
     elim_ring, elim_gens = polynomial_ring(coefficient_ring(R), vcat(symbols(R), symbols(S)))
     inject_R = hom(R, elim_ring, elim_gens[1:ngens(R)])
     inject_S = hom(S, elim_ring, elim_gens[ngens(R) + 1:ngens(elim_ring)])
-    
-    I = ideal([inject_S(s) - inject_R(phi(s)) for s in gens(S)])
-    
+    I = ideal([inject_S(s)*inject_R(denominator(phi(s))) - inject_R(numerator(phi(s))) for s in gens(S)])
+    if U != nothing
+      RU, iota = localization(elim_ring, inject_R(U))
+      I = saturated_ideal(iota(I))
+    end
+
     if algorithm == :eliminate
       invariants = eliminate(I, elim_gens[1:ngens(R)])
     elseif algorithm == :f4


### PR DESCRIPTION
This fixes issue #20: the algorithm for constructing the ideal of the graph of the parametrization assumes that it is polynomial. But for, e.g., undirected Gaussian graphical models, it is rational.

This is fixed by taking localizations into account explicitly.