### PR TITLE
Better vanishing ideals

### DIFF
--- a/experimental/AlgebraicStatistics/src/CI.jl
+++ b/experimental/AlgebraicStatistics/src/CI.jl
@@ -52,6 +52,9 @@ function ci_stmt(I::Vector{Int}, J::Vector{Int}, K::Vector{Int}; symmetric=true,
   CIStmt(sort(I), sort(J), sort(unique(K)))
 end
 
+ci_stmt(i::Int, j::Int, K::Vector{Int}; symmetric=true, disjoint=true) =
+  ci_stmt([i], [j], K; symmetric=symmetric, disjoint=disjoint)
+
 @doc raw"""
     Base.:(==)(lhs::CIStmt, rhs::CIStmt)
 

--- a/experimental/AlgebraicStatistics/src/DiscreteGraphicalModels.jl
+++ b/experimental/AlgebraicStatistics/src/DiscreteGraphicalModels.jl
@@ -131,6 +131,16 @@ Dict{Tuple{Vector{Int64}, Tuple{Int64, Int64}}, QQMPolyRingElem} with 8 entries:
 end
 
 @doc raw"""
+    vanishing_ideal(M::DiscreteGraphicalModel{Graph{Undirected}, L} where L
+
+The vanishing ideal is toric of an undirected discrete graphical model
+is toric. Therefore its `vanishing_ideal` method defaults to `algorithm=:markov`.
+"""
+function vanishing_ideal(M::DiscreteGraphicalModel{Graph{Undirected}, L}) where L
+  vanishing_ideal(M; algorithm=:markov)
+end
+
+@doc raw"""
   parameterization(M::DiscreteGraphicalModel{Graph{Undirected}, L})
 
 Creates the polynomial map which parameterizes the vanishing ideal of the

--- a/experimental/AlgebraicStatistics/src/GaussianGraphicalModels.jl
+++ b/experimental/AlgebraicStatistics/src/GaussianGraphicalModels.jl
@@ -249,14 +249,18 @@ end
 @doc raw"""
     vanishing_ideal(M::GaussianGraphicalModel{Graph{Directed}, L} where L
 
-By a theorem of Boege, Kubjas, Misra and Solus, the vanishing ideal of a directed
-acyclic Gaussian graphical model can be computed by saturating the conditional
-independence ideal of its ordered pairwise Markov property at the principal minors
-corresponding to all parent sets in the graph. This saturation-based approach
-usually outperforms the elimination-based default for generic graphical models.
+The vanishing ideal of a directed acyclic Gaussian graphical model can be computed
+by saturating the conditional independence ideal of its ordered pairwise Markov
+property at the principal minors corresponding to all parent sets in the graph.
+This saturation-based approach usually outperforms the elimination-based default
+for general graphical models.
+
+If the graph is cyclic, we fall back to elimination.
 """
 function vanishing_ideal(M::GaussianGraphicalModel{Graph{Directed}, L}) where L
-  @req is_acyclic(graph(M)) "the digraph must be acyclic"
+  if !is_acyclic(graph(M))
+    return vanishing_ideal(M; algorithm=:eliminate)
+  end
   G = graph(M)
   S, _ = model_ring(M)
   A = covariance_matrix(M)


### PR DESCRIPTION
This improves the default methods for vanishing ideals of graphical models:
* In the Gaussian case, use birational implicitization.
* In the discrete case, use 4ti2.

See the individual commit messages for timing and memory usage comparisons.